### PR TITLE
Dockerize

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+services:
+    flask:
+        hostname: flask
+        image: "oakland/flask"
+        ports:
+            - "5000:5000"
+        links:
+            - mongo:mongo
+    sockets:
+        hostname: sockets
+        image: "oakland/sockets"
+        ports:
+            - "5001:5001"
+        links:
+            - mongo:mongo
+    vue:
+        hostname: vue
+        image: "oakland/vue"
+        ports:
+            - "80:80"
+    mongo:
+        image: "mongo:latest"
+

--- a/docker.md
+++ b/docker.md
@@ -1,0 +1,92 @@
+# Docker
+
+## Install Docker CE
+
+* Docker can be installed [here](https://docs.docker.com/install/). Select your appropriate operating system.
+
+* Ensure you have Docker Compose as well.
+
+## Getting to know Docker
+
+* Read somoe of the basic concepts of docker [here](https://docs.docker.com/get-started/#docker-concepts)
+
+## Building the vue image
+
+* Go to the `vue` directory. You will see that we have a [Dockerfile](vue/Dockerfile) that defines our container.
+
+* To build our image run the following command:
+
+```
+docker build -t oakland/vue .
+```
+
+Run the command `docker images`. You should see something similar to this.
+
+```
+
+REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+oakland/vue         latest              8fa22c876cae        3 minutes ago       376MB
+node                alpine              a88ff852e3d4        3 hours ago         68MB
+```
+
+## Building the Flask image
+
+* Go the the `server` directory where you will find two Dockerfiles, We will use the [Dockerfile-flask](server/Dockerfile-flask) file.
+
+* To build our image run the following command:
+
+```
+docker build -t oakland/flask . -f Dockerfile-flask
+```
+
+Run the `docker images` command. You should see something similar:
+
+```
+REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+oakland/flask       latest              4c4ba5679d46        5 minutes ago       782MB
+oakland/vue         latest              8fa22c876cae        21 minutes ago      376MB
+node                alpine              a88ff852e3d4        3 hours ago         68MB
+python              jessie              336d482502ab        6 days ago          692MB
+```
+
+## Building the Flask SocketIO image
+
+* Go the the `server` directory where you will find two Dockerfiles, We will use the [Dockerfile-sockets](server/Dockerfile-sockets) file.
+
+* To build our image run the following command:
+
+```
+docker build -t oakland/sockets . -f Dockerfile-sockets
+```
+
+Run `docker images`. You should see something similar.
+
+```
+REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+oakland/sockets     latest              71759bb5f9b9        2 seconds ago       782MB
+oakland/flask       latest              4c4ba5679d46        9 minutes ago       782MB
+oakland/vue         latest              8fa22c876cae        25 minutes ago      376MB
+node                alpine              a88ff852e3d4        3 hours ago         68MB
+python              jessie              336d482502ab        6 days ago          692MB
+```
+
+## Docker Compose
+
+* We currently have a multi-container Docker application. So to easily start all our services we will use [Docker Compose](https://docs.docker.com/compose/overview/)
+
+* To start Docker Compose run the following:
+
+```
+docker-compose up
+```
+Go to [localhost](http://localhost) in your browser.
+
+## Wrapping up
+
+* Should you ever make a change to one of the images. You will need to rebuild it for Docker Compose to recognize those changes.
+
+* To remove dangling and unused images use `docker system prune -a`
+
+* To see running containers use `docker ps`
+
+* If while closing Docker Compose doesn't stop the currently running containers use `docker-compose kill` to stop them.

--- a/docker.md
+++ b/docker.md
@@ -8,7 +8,7 @@
 
 ## Getting to know Docker
 
-* Read somoe of the basic concepts of docker [here](https://docs.docker.com/get-started/#docker-concepts)
+* Read some of the basic concepts of docker [here](https://docs.docker.com/get-started/#docker-concepts)
 
 ## Building the vue image
 
@@ -72,7 +72,7 @@ python              jessie              336d482502ab        6 days ago          
 
 ## Docker Compose
 
-* We currently have a multi-container Docker application. So to easily start all our services we will use [Docker Compose](https://docs.docker.com/compose/overview/)
+* We currently have a multi-container Docker application. So to easily start all of our services we will use [Docker Compose](https://docs.docker.com/compose/overview/)
 
 * To start Docker Compose run the following:
 
@@ -83,10 +83,24 @@ Go to [localhost](http://localhost) in your browser.
 
 ## Wrapping up
 
-* Should you ever make a change to one of the images. You will need to rebuild it for Docker Compose to recognize those changes.
+* Should you ever make a change to one of the images you will need to rebuild it for Docker Compose to recognize those changes.
 
 * To remove dangling and unused images use `docker system prune -a`
 
 * To see running containers use `docker ps`
 
-* If while closing Docker Compose doesn't stop the currently running containers use `docker-compose kill` to stop them.
+* If while closing Docker Compose and it doesn't stop the currently running containers use `docker-compose kill` to stop them.
+
+* If you want to enter into a running container you first need to have it's container id. So run `docker ps` to view all running containers and view their ids.
+
+    *  For the python containers:
+
+        * `docker exec -it CONTAINER_ID /bin/bash`
+
+    * For the mongo container:
+
+        * `docker exec -it CONTAINER_ID mongo`
+
+    * For the vue container:
+
+        * `docker exec -it CONTAINER_ID /bin/ash`

--- a/docker.md
+++ b/docker.md
@@ -74,7 +74,7 @@ python              jessie              336d482502ab        6 days ago          
 
 * We currently have a multi-container Docker application. So to easily start all of our services we will use [Docker Compose](https://docs.docker.com/compose/overview/)
 
-* To start Docker Compose run the following:
+* To start Docker Compose run the following from the root of the project:
 
 ```
 docker-compose up
@@ -82,6 +82,8 @@ docker-compose up
 Go to [localhost](http://localhost) in your browser.
 
 ## Wrapping up
+
+* NOTE: For the mongo container to be accessible to our python containers we need to change  `MONGODB_HOST` inside [config.py](server/config.py) from `localhost` to `mongo` to match the containers Hostname. For the dev environment simply revert back to `localhost` and the `dev.sh` script will work as expected.
 
 * Should you ever make a change to one of the images you will need to rebuild it for Docker Compose to recognize those changes.
 

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,69 @@
+# Docker
+docker-compose.yml
+.docker
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*/__pycache__/
+*/*/__pycache__/
+  */*/*/__pycache__/
+  *.py[cod]
+      */*.py[cod]
+        */*/*.py[cod]
+            */*/*/*.py[cod]
+
+# C extensions
+                  *.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+                  *.egg-info/
+                  .installed.cfg
+                  *.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+                  *.mo
+                  *.pot
+
+# Virtual environment
+.env/
+.venv/
+venv/
+
+# PyCharm
+.idea
+
+# Python mode for VIM
+.ropeproject
+                  */.ropeproject
+*/*/.ropeproject
+  */*/*/.ropeproject
+
+# Vim swap files
+      *.swp
+      */*.swp
+        */*/*.swp
+            */*/*/*.swp

--- a/server/Dockerfile-flask
+++ b/server/Dockerfile-flask
@@ -1,0 +1,7 @@
+FROM python:jessie
+
+COPY . /app
+WORKDIR /app
+RUN pip --no-cache-dir install -r requirements.txt
+
+CMD [ "python", "server.py" ]

--- a/server/Dockerfile-sockets
+++ b/server/Dockerfile-sockets
@@ -1,0 +1,7 @@
+FROM python:jessie
+
+COPY . /app
+WORKDIR /app
+RUN pip --no-cache-dir install -r requirements.txt
+
+CMD [ "python", "somesockets.py" ]

--- a/server/config.py
+++ b/server/config.py
@@ -1,11 +1,12 @@
 import secrets
+
 from flask import current_app
 
 DEBUG = True
 SECRET_KEY = secrets.SECRET_KEY
 
 MONGODB_DB = 'mydatabase'
-MONGODB_HOST = 'localhost'
+MONGODB_HOST = 'mongo'
 MONGODB_PORT = 27017
 
 # CORS Config

--- a/server/server.py
+++ b/server/server.py
@@ -2,12 +2,12 @@ import secrets
 from json import loads
 
 from flask import Blueprint, Flask, jsonify, render_template, request, url_for
+from flask_cors import CORS
 from flask_mongoengine import MongoEngine
 
 from api import *
 from constants import internal_error, json_tag, malformed_request
 from decorators import *
-from flask_cors import CORS
 from helper import *
 from models import *
 
@@ -165,4 +165,4 @@ if __name__ == '__main__':
             send_email(text=' '.join(args.email), recipients=args.recipients)
         exit()
     app.register_blueprint(api)
-    app.run()
+    app.run(host='0.0.0.0')

--- a/server/somesockets.py
+++ b/server/somesockets.py
@@ -1,10 +1,11 @@
-from flask import Flask, render_template, request
-from flask_socketio import SocketIO, send, emit
 from secrets import SOCKETIO_SECRET_KEY
-import models # import like this or you'll get circular dependencies
-from flask_mongoengine import MongoEngine
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import parse_qs, urlparse
 
+from flask import Flask, render_template, request
+from flask_mongoengine import MongoEngine
+from flask_socketio import SocketIO, emit, send
+
+import models  # import like this or you'll get circular dependencies
 
 #=====================================================
 # Global vars
@@ -55,12 +56,14 @@ def connect():
     join_room(code)
     emit('connect', dict(message="Another user connected"), room=code)
 
+
 @socketio.on('disconnect')
 def disconnect():
     # This function technically doesn't even need to exist;
     # by default socketio handles room disconnection.
     # This is here purely in case we want to do anything additional.
     pass
+
 
 @socketio.on('update')
 def update(map_id, room):
@@ -76,8 +79,10 @@ if __name__ == "__main__":
     from argparse import ArgumentParser
 
     parser = ArgumentParser(description="Socket server for ARTop")
-    parser.add_argument("host", type=str, nargs='?', help="The IP addr you want to listen for", default='127.0.0.1')
-    parser.add_argument("port", type=int, nargs='?', help="The port you want the server to run on", default=5000)
+    parser.add_argument("host", type=str, nargs='?',
+                        help="The IP addr you want to listen for", default='0.0.0.0')
+    parser.add_argument("port", type=int, nargs='?',
+                        help="The port you want the server to run on", default=5001)
     args = parser.parse_args()
 
     if args.port < 80:

--- a/vue/.dockerignore
+++ b/vue/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/vue/Dockerfile
+++ b/vue/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:alpine
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+ENV NPM_CONFIG_LOGLEVEL info
+
+WORKDIR /app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN npm install
+
+# Bundle app source
+COPY . .
+
+RUN npm install http-server -g
+
+RUN npm run build
+
+CMD [ "http-server", "dist", "-p", "80" ]
+


### PR DESCRIPTION
Closes #192 

Notes:

- For the python containers to connect to the mongo container `MONGODB_HOST`  inside [config.py](https://github.com/joshherkness/AR-Top/compare/192-dockerize?expand=1#diff-dddcef56ec3e024a355dfba66fba8444R9) must be changed to match the containers hostname.  Doing so prevents the `dev.sh` script from connecting to mongo properly. To fix this simply replace `mongo` with `localhost`. 